### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,7 @@ Nuxt Well-Known module is integrated with the [Nuxt Devtools](https://github.com
 1. Add `@zadigetvoltaire/nuxt-well-known` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D @zadigetvoltaire/nuxt-well-known
-
-# Using yarn
-yarn add --dev @zadigetvoltaire/nuxt-well-known
-
-# Using npm
-npm install --save-dev @zadigetvoltaire/nuxt-well-known
+npx nuxi@latest module add well-known
 ```
 
 2. Add `@zadigetvoltaire/nuxt-well-known` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
